### PR TITLE
Fix Puppeteer CI issues: install Chrome and use new headless mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           DEBUG: true
           VOLTA_FEATURE_PNPM: 1
-        run: pnpm staging:deploy
+        run: node node_modules/puppeteer/install.mjs && pnpm staging:deploy
       - run: git log --pretty=%h -n1 > dist/REVISION.txt
       - name: Upload Build for next job
         uses: actions/upload-artifact@v4

--- a/smoke.mjs
+++ b/smoke.mjs
@@ -34,7 +34,8 @@ async function test(startServerFn, testSelector) {
     let { serverProcess, port } = await startServerFn();
     server = serverProcess;
     const browser = await puppeteer.launch({
-      args: [process.env.CI ? '--no-sandbox' : null],
+      headless: 'new',
+      args: [process.env.CI ? '--no-sandbox' : null].filter(Boolean),
     });
     const page = await browser.newPage();
     await page.goto(`http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- Fix Chrome installation issue causing CI staging deploy to fail by adding Puppeteer Chrome install step before deployment
- Update smoke test to use new Puppeteer headless mode to resolve deprecation warning and improve compatibility